### PR TITLE
Fix GitHub community issues and pagination issue

### DIFF
--- a/tap_twilio/schemas/usage_triggers.json
+++ b/tap_twilio/schemas/usage_triggers.json
@@ -32,7 +32,8 @@
       "type": ["null", "string"]
     },
     "current_value": {
-      "type": ["null", "integer"]
+      "type": ["null", "number"],
+      "multipleOf": 1e-8
     },
     "date_created": {
       "type": ["null", "string"],

--- a/tap_twilio/streams.py
+++ b/tap_twilio/streams.py
@@ -254,7 +254,6 @@ STREAMS = {
                 'api_version': '2010-04-01',
                 'path': 'Accounts/{ParentId}/Messages.json',
                 'data_key': 'messages',
-                'sub_resource_key': 'media',
                 'key_properties': ['sid'],
                 'replication_method': 'INCREMENTAL',  # Filter query
                 'replication_keys': ['date_sent'],
@@ -269,6 +268,7 @@ STREAMS = {
                         'api_version': '2010-04-01',
                         'path': 'Accounts/{AccountSid}/Messages/{ParentId}/Media.json',
                         'data_key': 'media_list',
+                        'sub_resource_key': 'media',
                         'key_properties': ['sid'],
                         'replication_method': 'FULL_TABLE',  # ALL for parent Address
                         'params': {},

--- a/tap_twilio/streams.py
+++ b/tap_twilio/streams.py
@@ -44,7 +44,7 @@ STREAMS = {
                     'dependent_phone_numbers': {
                         'api_url': 'https://api.twilio.com',
                         'api_version': '2010-04-01',
-                        'path': 'Accounts/{ParentId}/Addresses/{ParentId}/DependentPhoneNumbers.json',
+                        'path': 'Accounts/{AccountSid}/Addresses/{ParentId}/DependentPhoneNumbers.json',
                         'data_key': 'dependent_phone_numbers',
                         'key_properties': ['sid'],
                         'replication_method': 'FULL_TABLE',  # ALL for parent Address
@@ -74,6 +74,7 @@ STREAMS = {
                 'api_version': '2010-04-01',
                 'path': 'Accounts/{ParentId}/AvailablePhoneNumbers.json',
                 'data_key': 'countries',
+                'sub_resource_key': 'available_phone_numbers',
                 'key_properties': ['country_code'],
                 'replication_method': 'FULL_TABLE',
                 'params': {},
@@ -86,6 +87,7 @@ STREAMS = {
                         'api_version': '2010-04-01',
                         'path': 'Accounts/{AccountSid}/AvailablePhoneNumbers/{ParentId}/Local.json',
                         'data_key': 'available_phone_numbers',
+                        'sub_resource_key': 'local',
                         'key_properties': ['iso_country', 'phone_number'],
                         'replication_method': 'FULL_TABLE',  # ALL for parent Address
                         'params': {},
@@ -99,6 +101,7 @@ STREAMS = {
                         'api_version': '2010-04-01',
                         'path': 'Accounts/{AccountSid}/AvailablePhoneNumbers/{ParentId}/Mobile.json',
                         'data_key': 'available_phone_numbers',
+                        'sub_resource_key': 'mobile',
                         'key_properties': ['iso_country', 'phone_number'],
                         'replication_method': 'FULL_TABLE',  # ALL for parent Address
                         'params': {},
@@ -112,6 +115,7 @@ STREAMS = {
                         'api_version': '2010-04-01',
                         'path': 'Accounts/{AccountSid}/AvailablePhoneNumbers/{ParentId}/TollFree.json',
                         'data_key': 'available_phone_numbers',
+                        'sub_resource_key': 'toll_free',
                         'key_properties': ['iso_country', 'phone_number'],
                         'replication_method': 'FULL_TABLE',  # ALL for parent Address
                         'params': {},
@@ -180,8 +184,9 @@ STREAMS = {
                     'conference_participants': {
                         'api_url': 'https://api.twilio.com',
                         'api_version': '2010-04-01',
-                        'path': 'Accounts/{ParentId}/Conferences/{ParentId}/Participants.json',
+                        'path': 'Accounts/{AccountSid}/Conferences/{ParentId}/Participants.json',
                         'data_key': 'participants',
+                        'sub_resource_key': 'participants',
                         'key_properties': ['uri'],
                         'replication_method': 'FULL_TABLE',  # ALL for parent Conference
                         'params': {},
@@ -213,7 +218,6 @@ STREAMS = {
                 'replication_method': 'INCREMENTAL',  # Filter query
                 'replication_keys': ['date_created'],
                 'bookmark_query_field_from': 'DateCreated>',  # Daily
-                'bookmark_query_field_to': 'DateCreated<',
                 'params': {},
                 'pagingation': 'root'
             },
@@ -250,11 +254,11 @@ STREAMS = {
                 'api_version': '2010-04-01',
                 'path': 'Accounts/{ParentId}/Messages.json',
                 'data_key': 'messages',
+                'sub_resource_key': 'media',
                 'key_properties': ['sid'],
                 'replication_method': 'INCREMENTAL',  # Filter query
                 'replication_keys': ['date_sent'],
                 'bookmark_query_field_from': 'DateSent>',  # Daily
-                'bookmark_query_field_to': 'DateSent<',
                 'params': {},
                 'pagingation': 'root',
                 'children': {
@@ -282,8 +286,8 @@ STREAMS = {
                 'key_properties': ['account_sid', 'category', 'start_date'],
                 'replication_method': 'INCREMENTAL',  # Filter query
                 'replication_keys': ['end_date'],
-                'bookmark_query_field_from': 'StartDate',  # Daily
-                'bookmark_query_field_to': 'EndDate',
+                'bookmark_query_field_from': 'start_date',  # Daily
+                'bookmark_query_field_to': 'end_date',
                 'params': {},
                 'pagingation': 'root'
             },
@@ -313,8 +317,8 @@ STREAMS = {
         'key_properties': ['sid'],
         'replication_method': 'INCREMENTAL',  # Filter query
         'replication_keys': ['date_updated'],
-        'bookmark_query_field_from': 'StartDate',  # Bookmark
-        'bookmark_query_field_to': 'EndDate',  # Current Date
+        'bookmark_query_field_from': 'start_date',  # Bookmark
+        'bookmark_query_field_to': 'end_date',  # Current Date
         'max_days_ago': 30,
         'params': {},
         'pagingation': 'meta'

--- a/tap_twilio/sync.py
+++ b/tap_twilio/sync.py
@@ -326,6 +326,7 @@ def sync_endpoint(
                             # their endpoints will be in the results,
                             # this will grab the child path for the child stream we're syncing,
                             # if we're syncing it. If it doesn't exist we just skip it below.
+                            child_path = None
                             if child_stream_name in ("usage_records", "usage_triggers"):
                                 if 'usage' in record.get('_subresource_uris', {}):
                                     child_path = child_endpoint_config.get('path').format(

--- a/tap_twilio/sync.py
+++ b/tap_twilio/sync.py
@@ -248,13 +248,12 @@ def sync_endpoint(
                 break  # No data results
 
             # Get pagination details
-            pagination = data.get('meta', {}).get('pagination', {})
-            api_total = int(pagination.get('total_results', 0))
-            if pagination.get('next', {}).get('rel') == 'next':
-                next_url = pagination.get('next', {}).get('href')
+            if data.get("next_page_uri"):
+                next_url = endpoint_config.get("api_url") + data["next_page_uri"]
             else:
                 next_url = None
 
+            api_total = len(data.get(endpoint_config.get("data_key"), []))
             if not data or data is None:
                 total_records = 0
                 break  # No data results
@@ -327,8 +326,17 @@ def sync_endpoint(
                             # their endpoints will be in the results,
                             # this will grab the child path for the child stream we're syncing,
                             # if we're syncing it. If it doesn't exist we just skip it below.
-                            child_path = record.get('_subresource_uris', {})\
-                                .get(child_stream_name, None)
+                            if child_stream_name in ("usage_records", "usage_triggers"):
+                                if 'usage' in record.get('_subresource_uris', {}):
+                                    child_path = child_endpoint_config.get('path').format(
+                                        ParentId=parent_id)
+                            elif child_stream_name == 'dependent_phone_numbers':
+                                child_path = child_endpoint_config.get('path').format(
+                                    ParentId=parent_id, AccountSid=config.get('account_sid'))
+                            else:
+                                child_path = record.get('_subresource_uris', {}).get(
+                                    child_endpoint_config.get('sub_resource_key',
+                                                              child_stream_name))
                             child_bookmark_field = next(iter(child_endpoint_config.get(
                                 'replication_keys', [])), None)
 


### PR DESCRIPTION
# Description of change

1. Fixes #1 
2. Currently tap isn't pulling data for some of the streams due to invalid `query_params`. Updated query_params for `messages`, `alerts`, `recordings` streams
3. Updates data_type for `current_value` field of `usage_triggers` stream to `number`
4. Fixes pagination issue. `next_page_uri` value is available at the root level in the API response.
**Sample API Response:**

> {
    "first_page_uri": "/2010-04-01/Accounts/AC27c086be643ff0c7959e952fab8f901a/Applications.json?PageSize=50&Page=0",
    "end": 0,
    "previous_page_uri": null,
    "uri": "/2010-04-01/Accounts/AC27c086be643ff0c7959e952fab8f901a/Applications.json?PageSize=50&Page=0",
    "page_size": 50,
    "page": 0,
    "applications": [],
    "next_page_uri": null,
    "start": 0
}


# Manual QA steps
 - Ran Integration tests to make sure data is being extracted for all the streams
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
