### PR TITLE
automate replication key field selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 0.0.2
+  * Automates field selection for replication keys [#5](https://github.com/singer-io/tap-twilio/pull/5)
+
 ## 0.0.1
   * Initial commit

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='tap-twilio',
       install_requires=[
           'backoff==1.8.0',
           'requests==2.23.0',
-          'singer-python==5.9.0'
+          'singer-python==5.13.0'
       ],
       entry_points='''
           [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-twilio',
-      version='0.0.1',
+      version='0.0.2',
       description='Singer.io tap for extracting data from the Twilio API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_twilio/schema.py
+++ b/tap_twilio/schema.py
@@ -1,13 +1,12 @@
 import os
 import json
-from singer import metadata
+from singer.metadata import get_standard_metadata, to_list, to_map, write
 from tap_twilio.streams import flatten_streams
 
-# Reference:
-# https://github.com/singer-io/getting-started/blob/master/docs/DISCOVERY_MODE.md#Metadata
 
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
+
 
 def get_schemas():
     schemas = {}
@@ -16,21 +15,23 @@ def get_schemas():
     flat_streams = flatten_streams()
     for stream_name, stream_metadata in flat_streams.items():
         schema_path = get_abs_path('schemas/{}.json'.format(stream_name))
-        with open(schema_path) as file:
+        with open(schema_path, encoding="utf-8") as file:
             schema = json.load(file)
         schemas[stream_name] = schema
-        mdata = metadata.new()
 
-        # Documentation:
-        # https://github.com/singer-io/getting-started/blob/master/docs/DISCOVERY_MODE.md#singer-python-helper-functions
-        # Reference:
-        # https://github.com/singer-io/singer-python/blob/master/singer/metadata.py#L25-L44
-        mdata = metadata.get_standard_metadata(
-            schema=schema,
-            key_properties=stream_metadata.get('key_properties', None),
-            valid_replication_keys=stream_metadata.get('replication_keys', None),
-            replication_method=stream_metadata.get('replication_method', None)
+        mdata = get_standard_metadata(
+            **{
+                "schema": schema,
+                "key_properties": stream_metadata.get('key_properties', None),
+                "valid_replication_keys": stream_metadata.get('replication_keys', None),
+                "replication_method": stream_metadata.get('replication_method', None),
+            }
         )
+        mdata = to_map(mdata)
+        if stream_metadata.get('replication_keys') is not None:
+            for key in stream_metadata.get('replication_keys'):
+                mdata = write(mdata, ("properties", key), "inclusion", "automatic")
+        mdata = to_list(mdata)
         field_metadata[stream_name] = mdata
 
     return schemas, field_metadata


### PR DESCRIPTION
# Description of change
This PR automates field selection for replication keys and upgrades `singer-python`

# Manual QA steps
 - Ran the tap in discovery mode and saw the replication keys getting automatically selected
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
