### PR TITLE
Implement lookback window for messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.0
+  * Implement lookback window for messages [#10](https://github.com/singer-io/tap-twilio/pull/10)
+
 ## 0.1.1
   * Fix Dependabot issue [#9](https://github.com/singer-io/tap-twilio/pull/9)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-twilio',
-      version='0.1.1',
+      version='0.2.0',
       description='Singer.io tap for extracting data from the Twilio API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_twilio/streams.py
+++ b/tap_twilio/streams.py
@@ -267,7 +267,7 @@ STREAMS = {
                 'data_key': 'messages',
                 'key_properties': ['sid'],
                 'replication_method': 'INCREMENTAL',  # Filter query
-                'replication_keys': ['date_updated'],
+                'replication_keys': ['date_sent'],
                 'bookmark_query_field_from': 'DateSent>',  # Daily
                 'bookmark_query_field_to': 'DateSent<',
                 'params': {},

--- a/tap_twilio/sync.py
+++ b/tap_twilio/sync.py
@@ -134,7 +134,7 @@ def get_dates(state, stream_name, start_date, bookmark_field, bookmark_query_fie
     last_datetime = get_bookmark(state, stream_name, start_date)
     if stream_name == "messages":
         # The API supports querying only by date_sent, not date_updated.
-        # To retrieve updates from the past few days, use lookback_window is used.
+        # To retrieve updates for the past some days, lookback_window is used.
         last_datetime =  strftime(strptime_to_utc(last_datetime) - timedelta(days=lookback_window))
 
     max_bookmark_value = last_datetime

--- a/tests/base.py
+++ b/tests/base.py
@@ -186,7 +186,7 @@ class TwilioBaseTest(unittest.TestCase):
             "messages": {
                 self.PRIMARY_KEYS: {"sid"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"date_updated"},
+                self.REPLICATION_KEYS: {"date_sent"},
                 self.EXPECTED_PAGE_SIZE: 50,
                 self.OBEYS_START_DATE: True
             },

--- a/tests/base.py
+++ b/tests/base.py
@@ -35,7 +35,7 @@ class TwilioBaseTest(unittest.TestCase):
     # Skipping below streams beacuse they require a paid account to generate data
     NO_DATA_STREAMS = {"applications", "conference_participants", "dependent_phone_numbers", \
                    "transcriptions", "message_media", "messages", "alerts", \
-                   "calls", "incoming_phone_numbers"}
+                   "calls", "incoming_phone_numbers", "conferences"}
 
     # Fail the test when the JIRA card is done to allow streams to be re-added and tested
     jira_status = JIRA_CLIENT.get_status_category('TDL-26951')


### PR DESCRIPTION
# Description of change
Update the `replication_key` to `date_sent` and query records based on that field. To ensure messages updates are not missed, we implement a lookback window logic as part of this PR. This means we will always fetch records from a few days before the last saved bookmark. 

For example, if the last saved bookmark is `20-04-2025`, the next extraction will fetch records from `05-04-2025 (assuming a 15-day lookback)`. This approach will capture all updates made in the last 15 days, as well as any new messages created during that period.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
