### PR TITLE
SAC-28895 meta data changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.0
+  * Added Parent Relationship to the child streams for metadata [#15](https://github.com/singer-io/tap-twilio/pull/15)
+
 ## 0.2.1
   * Bump dependency versions for twistlock compliance [#12](https://github.com/singer-io/tap-twilio/pull/12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.3.0
-  * Added Parent Relationship to the child streams for metadata [#15](https://github.com/singer-io/tap-twilio/pull/15)
+  * Added Parent Relationship to the child streams for metadata [#18](https://github.com/singer-io/tap-twilio/pull/18)
 
 ## 0.2.1
   * Bump dependency versions for twistlock compliance [#12](https://github.com/singer-io/tap-twilio/pull/12)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-twilio',
       py_modules=['tap_twilio'],
       install_requires=[
           'backoff==1.10.0',
-          'requests==2.33.0',
+          'requests==2.34.2',
           'singer-python==5.13.2'
       ],
       entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-twilio',
-      version='0.2.1',
+      version='0.3.0',
       description='Singer.io tap for extracting data from the Twilio API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_twilio/schema.py
+++ b/tap_twilio/schema.py
@@ -31,6 +31,11 @@ def get_schemas():
         if stream_metadata.get('replication_keys') is not None:
             for key in stream_metadata.get('replication_keys'):
                 mdata = write(mdata, ("properties", key), "inclusion", "automatic")
+
+        parent_stream = stream_metadata.get('parent_stream')
+        if parent_stream:
+            mdata.setdefault((), {}).update({"parent-tap-stream-id": parent_stream})
+
         mdata = to_list(mdata)
         field_metadata[stream_name] = mdata
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -90,14 +90,16 @@ class TwilioBaseTest(unittest.TestCase):
                 self.PRIMARY_KEYS: {"account_sid"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.EXPECTED_PAGE_SIZE: 1,
-                self.OBEYS_START_DATE: False
+                self.OBEYS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "accounts"
             },
             "addresses": {
                 self.PRIMARY_KEYS: {"sid"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date_updated"},
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: True
+                self.OBEYS_START_DATE: True,
+                self.EXPECTED_PARENT_STREAM: "accounts"
             },
             "alerts": {
                 self.PRIMARY_KEYS: {"sid"},
@@ -111,126 +113,145 @@ class TwilioBaseTest(unittest.TestCase):
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date_updated"},
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: True
+                self.OBEYS_START_DATE: True,
+                self.EXPECTED_PARENT_STREAM: "accounts"
             },
             "available_phone_number_countries": {
                 self.PRIMARY_KEYS: {"country_code"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: False
+                self.OBEYS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "accounts"
             },
             "available_phone_numbers_local": {
                 self.PRIMARY_KEYS: {"iso_country", "phone_number"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: False
+                self.OBEYS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "available_phone_number_countries"
             },
             "available_phone_numbers_mobile": {
                 self.PRIMARY_KEYS: {"iso_country", "phone_number"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: False
+                self.OBEYS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "available_phone_number_countries"
             },
             "available_phone_numbers_toll_free": {
                 self.PRIMARY_KEYS: {"iso_country", "phone_number"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: False
+                self.OBEYS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "available_phone_number_countries"
             },
             "calls": {
                 self.PRIMARY_KEYS: {"sid"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date_updated"},
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: True
+                self.OBEYS_START_DATE: True,
+                self.EXPECTED_PARENT_STREAM: "accounts"
             },
             "conference_participants": {
                 self.PRIMARY_KEYS: {"uri"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: False
+                self.OBEYS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "conferences"
             },
             "conferences": {
                 self.PRIMARY_KEYS: {"sid"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date_updated"},
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: True
+                self.OBEYS_START_DATE: True,
+                self.EXPECTED_PARENT_STREAM: "accounts"
             },
             "dependent_phone_numbers": {
                 self.PRIMARY_KEYS: {"sid"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: False
+                self.OBEYS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "addresses"
             },
             "incoming_phone_numbers": {
                 self.PRIMARY_KEYS: {"sid"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date_updated"},
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: True
+                self.OBEYS_START_DATE: True,
+                self.EXPECTED_PARENT_STREAM: "accounts"
             },
             "keys": {
                 self.PRIMARY_KEYS: {"sid"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date_updated"},
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: True
+                self.OBEYS_START_DATE: True,
+                self.EXPECTED_PARENT_STREAM: "accounts"
             },
             "message_media": {
                 self.PRIMARY_KEYS: {"sid"},
                 self.REPLICATION_METHOD: self.FULL_TABLE,
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: False
+                self.OBEYS_START_DATE: False,
+                self.EXPECTED_PARENT_STREAM: "messages"
             },
             "messages": {
                 self.PRIMARY_KEYS: {"sid"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date_sent"},
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: True
+                self.OBEYS_START_DATE: True,
+                self.EXPECTED_PARENT_STREAM: "accounts"
             },
             "outgoing_caller_ids": {
                 self.PRIMARY_KEYS: {"sid"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date_updated"},
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: True
+                self.OBEYS_START_DATE: True,
+                self.EXPECTED_PARENT_STREAM: "accounts"
             },
             "queues": {
                 self.PRIMARY_KEYS: {"sid"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date_updated"},
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: True
+                self.OBEYS_START_DATE: True,
+                self.EXPECTED_PARENT_STREAM: "accounts"
             },
             "recordings": {
                 self.PRIMARY_KEYS: {"sid"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date_created"},
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: True
+                self.OBEYS_START_DATE: True,
+                self.EXPECTED_PARENT_STREAM: "accounts"
             },
             "transcriptions": {
                 self.PRIMARY_KEYS: {"sid"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date_updated"},
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: True
+                self.OBEYS_START_DATE: True,
+                self.EXPECTED_PARENT_STREAM: "accounts"
             },
             "usage_records": {
                 self.PRIMARY_KEYS: {"account_sid", "category", "start_date"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"start_date"},
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: True
+                self.OBEYS_START_DATE: True,
+                self.EXPECTED_PARENT_STREAM: "accounts"
             },
             "usage_triggers": {
                 self.PRIMARY_KEYS: {"sid"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date_updated"},
                 self.EXPECTED_PAGE_SIZE: 50,
-                self.OBEYS_START_DATE: True
+                self.OBEYS_START_DATE: True,
+                self.EXPECTED_PARENT_STREAM: "accounts"
             }
         }
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -61,6 +61,7 @@ class DiscoveryTest(TwilioBaseTest):
                 expected_replication_keys = self.expected_replication_keys()[stream]
                 expected_automatic_fields = self.expected_automatic_fields()[stream]
                 expected_replication_method = self.expected_replication_method()[stream]
+                expected_parent_stream = self.expected_metadata()[stream].get(self.EXPECTED_PARENT_STREAM)
 
                 # collecting actual values
                 schema_and_metadata = menagerie.get_annotated_schema(conn_id, catalog["stream_id"])
@@ -75,6 +76,9 @@ class DiscoveryTest(TwilioBaseTest):
                 actual_replication_method = (
                     stream_properties[0].get("metadata", {self.REPLICATION_METHOD: None}).get(self.REPLICATION_METHOD)
                 )
+                stream_metadata = stream_properties[0].get("metadata", {})
+                actual_parent_stream = stream_metadata.get("parent-tap-stream-id")
+
                 actual_automatic_fields = {
                     item.get("breadcrumb", ["properties", None])[1]
                     for item in metadata
@@ -139,3 +143,16 @@ class DiscoveryTest(TwilioBaseTest):
                     ),
                     msg="Not all non key properties are set to available in metadata",
                 )
+
+                if expected_parent_stream:
+                    self.assertEqual(
+                        expected_parent_stream,
+                        actual_parent_stream,
+                        msg=f"Expected parent stream for {stream} is {expected_parent_stream} "
+                            f"but found {actual_parent_stream}",
+                    )
+                else:
+                    self.assertIsNone(
+                        actual_parent_stream,
+                        msg=f"{stream} should not have a parent stream but found {actual_parent_stream}",
+                    )


### PR DESCRIPTION
# Description of change

[SAC-28895](https://qlik-dev.atlassian.net/browse/SAC-28895)
This PR adds parent-child stream relationship metadata to the Twilio tap connector. The changes enable tracking of hierarchical dependencies between streams (e.g., "accounts" is the parent of "addresses", "calls", etc.).

**Key Changes:**
- Adds `EXPECTED_PARENT_STREAM` metadata field to stream definitions
- Implements validation logic to verify parent stream relationships in discovery tests
- Updates schema generation to include parent stream information in metadata

### Changes

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| tests/base.py | Adds `EXPECTED_PARENT_STREAM` field to all stream metadata definitions |
| tests/test_discovery.py | Implements test assertions to validate parent stream metadata |
| tap_twilio/schema.py | Updates schema generation to populate `parent-tap-stream-id` metadata |
| setup.py | Bumps version from 0.2.1 to 0.3.0 |
| CHANGELOG.md | Documents the new parent relationship feature |
</details>


# Manual QA steps
 - Comment the client connect in the code to generate the catalog file.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
